### PR TITLE
Add dice roller UI and animations

### DIFF
--- a/public/action.css
+++ b/public/action.css
@@ -252,3 +252,33 @@ button:disabled {
 
 }
 
+
+/* Dice roller */
+.dice-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.die {
+  width: 40px;
+  height: 40px;
+  background: #fff;
+  color: #000;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.die.rolling {
+  animation: roll 1s linear;
+}
+
+@keyframes roll {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(720deg); }
+}

--- a/public/action.html
+++ b/public/action.html
@@ -134,11 +134,16 @@
     <!-- Dice Roller -->
 
     <section id="dice-roller" class="panel dice-roller">
-
       <h2>Dice Roller</h2>
-
-      <div id="dice-output">No rolls yet.</div>
-
+      <label for="dice-type">Die Type:</label>
+      <select id="dice-type">
+        <option value="6">d6</option>
+        <option value="20">d20</option>
+      </select>
+      <label for="dice-count">Quantity:</label>
+      <input type="number" id="dice-count" min="1" max="20" value="1">
+      <button id="roll-dice">Roll Dice</button>
+      <div id="dice-results" class="dice-container"></div>
     </section>
 
 

--- a/public/action.js
+++ b/public/action.js
@@ -249,6 +249,54 @@ function onDodge()  { addLog(`${currentName()} Dodges.`); }
 function onInterrupt(){ addLog(`${currentName()} Interrupts.`); }
 
 
+// --- Dice Roller ---
+function randomInt(max) {
+  return Math.floor(Math.random() * max) + 1;
+}
+
+function animateDice(elements, sides, values, cb) {
+  const start = performance.now();
+  function frame(now) {
+    const elapsed = now - start;
+    if (elapsed < 1000) {
+      elements.forEach(el => {
+        el.textContent = randomInt(sides);
+      });
+      requestAnimationFrame(frame);
+    } else {
+      elements.forEach((el, i) => {
+        el.textContent = values[i];
+        el.classList.remove('rolling');
+      });
+      if (cb) cb();
+    }
+  }
+  elements.forEach(el => el.classList.add('rolling'));
+  requestAnimationFrame(frame);
+}
+
+function onRollDice() {
+  const sides = parseInt(document.getElementById('dice-type').value, 10);
+  let count = parseInt(document.getElementById('dice-count').value, 10);
+  count = Math.max(1, Math.min(20, count || 1));
+  const container = document.getElementById('dice-results');
+  container.innerHTML = '';
+  const diceElems = [];
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    const val = randomInt(sides);
+    results.push(val);
+    const d = document.createElement('div');
+    d.className = 'die';
+    d.textContent = val;
+    container.appendChild(d);
+    diceElems.push(d);
+  }
+  animateDice(diceElems, sides, results, () => {
+    addLog(`Rolled ${count}d${sides}: [${results.join(', ')}]`);
+  });
+}
+
 // --- Bootstrap ---
 
 async function init() {
@@ -280,6 +328,7 @@ async function init() {
   document.getElementById('do-dodge').addEventListener('click', onDodge);
 
   document.getElementById('do-interrupt').addEventListener('click', onInterrupt);
+  document.getElementById('roll-dice').addEventListener('click', onRollDice);
 
   // initial render
 


### PR DESCRIPTION
## Summary
- expand dice roller section on action page
- style dice display and animation
- implement dice roller logic and log results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4ca7f7c83298bc03c900c94dc12